### PR TITLE
Be less strict about case link urls

### DIFF
--- a/lib/Desk/service-description/models/Case.group/CaseModel.yaml
+++ b/lib/Desk/service-description/models/Case.group/CaseModel.yaml
@@ -17,39 +17,39 @@ properties:
         location: links
         data:
             operation: ShowCase
-            pattern: "#/cases/(?P<id>[0-9]+)$#"
+            pattern: "#/cases/(?P<id>[0-9]+)#"
     message:
         location: links
         data:
             operation: ShowCaseMessage
-            pattern: "#/cases/(?P<case_id>[0-9]+)/message$#"
+            pattern: "#/cases/(?P<case_id>[0-9]+)/message#"
     customer:
         location: links
         data:
             operation: ShowCustomer
-            pattern: "#/customers/(?P<id>[0-9]+)$#"
+            pattern: "#/customers/(?P<id>[0-9]+)#"
     assigned_user:
         location: links
         data:
             operation: ShowUser
-            pattern: "#/users/(?P<id>[0-9]+)$#"
+            pattern: "#/users/(?P<id>[0-9]+)#"
     assigned_group:
         location: links
         data:
             operation: ShowGroup
-            pattern: "#/groups/(?P<id>[0-9]+)$#"
+            pattern: "#/groups/(?P<id>[0-9]+)#"
     locked_by:
         location: links
         data:
             operation: ShowUser
-            pattern: "#/users/(?P<id>[0-9]+)$#"
+            pattern: "#/users/(?P<id>[0-9]+)#"
     replies:
         location: links
         data:
             operation: ListCaseReplies
-            pattern: "#/cases/(?P<case_id>[0-9]+)/replies$#"
+            pattern: "#/cases/(?P<case_id>[0-9]+)/replies#"
     notes:
         location: links
         data:
             operation: ListCaseNotes
-            pattern: "#/cases/(?P<case_id>[0-9]+)/notes$#"
+            pattern: "#/cases/(?P<case_id>[0-9]+)/notes#"

--- a/tests/mock/Desk/Test/Operation/Cases/CreateCaseOperationTest/system.txt
+++ b/tests/mock/Desk/Test/Operation/Cases/CreateCaseOperationTest/system.txt
@@ -34,27 +34,27 @@ Connection: keep-alive
     },
     "_links": {
         "self": {
-            "href": "/api/v2/cases/1",
+            "href": "/api/v2/cases/1?page=1&per_page=50",
             "class": "case"
         },
         "message": {
-            "href": "/api/v2/cases/1/message",
+            "href": "/api/v2/cases/1/message?page=1&per_page=50",
             "class": "message"
         },
         "customer": {
-            "href": "/api/v2/customers/1",
+            "href": "/api/v2/customers/1?page=1&per_page=50",
             "class": "customer"
         },
         "assigned_user": {
-            "href": "/api/v2/users/1",
+            "href": "/api/v2/users/1?page=1&per_page=50",
             "class": "user"
         },
         "assigned_group": {
-            "href": "/api/v2/groups/1",
+            "href": "/api/v2/groups/1?page=1&per_page=50",
             "class": "group"
         },
         "locked_by": {
-            "href": "/api/v2/users/1",
+            "href": "/api/v2/users/1?page=1&per_page=50",
             "class": "user"
         }
     }


### PR DESCRIPTION
When calling `CreateCase` I'm seeing failures like:

```
Desk\Exception\UnexpectedValueException Couldn't parse parameters from link href (pattern given was '#/cases/(?P<id>[0-9]+)$#', href was '/api/v2/cases?page=1&per_page=50')
    /home/user/projectname/vendor/bradfeehan/desk-php/lib/Desk/Relationship/Resource/CommandBuilder.php:82 parseHref
    /home/user/projectname/vendor/bradfeehan/desk-php/lib/Desk/Relationship/Resource/CommandBuilder.php:25 createLinkCommand
    /home/user/projectname/vendor/bradfeehan/desk-php/lib/Desk/Relationship/Visitor/Response/LinksVisitor.php:76 visit
    /home/user/projectname/vendor/guzzle/guzzle/src/Guzzle/Service/Command/OperationResponseParser.php:148 visitResult
    /home/user/projectname/vendor/bradfeehan/desk-php/lib/Desk/Relationship/ResponseParser.php:74 handleParsing
    /home/user/projectname/vendor/guzzle/guzzle/src/Guzzle/Service/Command/DefaultResponseParser.php:39 parse
    /home/user/projectname/vendor/guzzle/guzzle/src/Guzzle/Service/Command/OperationCommand.php:87 process
    /home/user/projectname/vendor/guzzle/guzzle/src/Guzzle/Service/Command/AbstractCommand.php:193 getResult
    /home/user/projectname/vendor/guzzle/guzzle/src/Guzzle/Service/Client.php:138 execute
    /home/user/projectname/vendor/guzzle/guzzle/src/Guzzle/Service/Command/AbstractCommand.php:153 execute
    /home/user/projectname/vendor/guzzle/guzzle/src/Guzzle/Service/Command/AbstractCommand.php:189 getResult
    /home/user/projectname/vendor/guzzle/guzzle/src/Guzzle/Service/Client.php:76 __call
    /home/user/projectname/CreateCaseTask.php:304 CreateCase
    ...

```

This is happening because the regex doesn't expect there to be any query params.

This updates the link regex to be less strict for the case API - similar updates may need to happen for other models, but this fixes my use-case
