### PR TITLE
Add the ability to get a case's history

### DIFF
--- a/lib/Desk/service-description/models/Case.group/CaseModel.yaml
+++ b/lib/Desk/service-description/models/Case.group/CaseModel.yaml
@@ -53,3 +53,8 @@ properties:
         data:
             operation: ListCaseNotes
             pattern: "#/cases/(?P<case_id>[0-9]+)/notes$#"
+    history:
+        location: links
+        data:
+            operation: ListCaseHistory
+            pattern: "#/cases/(?P<case_id>[0-9]+)/history$#"

--- a/lib/Desk/service-description/models/Case.group/History.group/CaseHistoryModel.yaml
+++ b/lib/Desk/service-description/models/Case.group/History.group/CaseHistoryModel.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+    type:         { extends: CaseHistoryModel.type }
+    context:      { extends: CaseHistoryModel.context }
+    created_at:   { extends: CaseHistoryModel.created_at }
+    changes:      { extends: CaseHistoryModel.changes }
+    self:
+        location: links
+        data:
+            operation: ShowCaseHistory
+            pattern: "#/cases/(?P<case_id>[0-9]+)/history/(?P<attachment_id>[0-9]+)$#"

--- a/lib/Desk/service-description/models/Case.group/History.group/CaseHistoryPage.yaml
+++ b/lib/Desk/service-description/models/Case.group/History.group/CaseHistoryPage.yaml
@@ -7,8 +7,8 @@ properties:
     self: &SELF
         location: links
         data:
-            operation: ListCases
-            pattern: "#/cases\\??(?P<_query>.*)$#"
+            operation: ListCaseHistory
+            pattern: "#/cases/(?P<case_id>[0-9]+)/history\\??(?P<_query>.*)$#"
     first: *SELF
     last: *SELF
     next: *SELF

--- a/lib/Desk/service-description/models/Case.group/History.group/CaseHistoryPage.yaml
+++ b/lib/Desk/service-description/models/Case.group/History.group/CaseHistoryPage.yaml
@@ -1,0 +1,15 @@
+extends: page
+properties:
+    entries:
+        type: array
+        items: { extends: CaseHistoryModel }
+        location: embedded
+    self: &SELF
+        location: links
+        data:
+            operation: ListCases
+            pattern: "#/cases\\??(?P<_query>.*)$#"
+    first: *SELF
+    last: *SELF
+    next: *SELF
+    previous: *SELF

--- a/lib/Desk/service-description/models/Case.group/__index.yaml
+++ b/lib/Desk/service-description/models/Case.group/__index.yaml
@@ -210,3 +210,67 @@ CaseAttachmentModel.updated_at:
 CaseAttachmentModel.erased_at:
     extends: date.output
     description: Time at which an agent erased this attachment
+
+CaseHistoryModel.type:
+    extends: parameter
+    description: Type of history event for the case
+    type: string
+    enum:
+        - case_opened
+        - case_pending
+        - case_reopened
+        - case_resolved
+        - case_error_dismissed
+        - case_updated
+        - note_created
+        - note_erased
+        - customer_created
+        - customer_changed_from_merge
+        - macro_applied
+        - article_applied
+        - rule_applied
+        - email_pending_send
+        - email_sent
+        - email_sent_failure
+        - email_sent_ack
+        - email_sent_ticket_forward
+        - email_content_erased
+        - tweet_pending_send
+        - tweet_sent
+        - tweet_sent_failure
+        - tweet_content_erased
+        - tweet_retweeted
+        - facebook_pending_send
+        - facebook_sent
+        - facebook_sent_failure
+        - facebook_post_content_erased
+        - facebook_comment_content_erased
+        - facebook_content_liked
+        - facebook_content_unliked
+        - facebook_content_deleted
+        - question_hidden
+        - question_unhidden
+        - question_allow_answers
+        - question_disallow_answers
+        - answer_marked_best
+        - answer_unmarked_best
+        - attachment_created
+        - attachment_deleted
+        - attachment_erased
+        - phone_content_erased
+        - queue_item_pulled
+        - queue_item_accept
+        - queue_item_transferred_queue
+        - queue_item_putback
+        - queue_item_timeout
+
+CaseHistoryModel.context:
+    extends: parameter
+    description: Context id of the event
+    type: string
+CaseHistoryModel.created_at:
+    extends: date.output
+    description: Time at which the event was created
+CaseHistoryModel.changes:
+    extends: parameter
+    type: object

--- a/lib/Desk/service-description/operations/Case.group/History.group/ListCaseHistory.yaml
+++ b/lib/Desk/service-description/operations/Case.group/History.group/ListCaseHistory.yaml
@@ -1,0 +1,14 @@
+extends: list
+summary: Retrieve a paginated list of the history for a particular case
+uri: "cases/{case_id}/history"
+responseClass: CaseHistoryPage
+parameters:
+    case_id:
+        extends: id
+        description: The ID of the case to retrieve the history for
+        required: true
+        location: uri
+data:
+    embeds:
+        entries:
+            model: CaseHistoryModel

--- a/lib/Desk/service-description/operations/Case.group/History.group/ShowCaseHistory.yaml
+++ b/lib/Desk/service-description/operations/Case.group/History.group/ShowCaseHistory.yaml
@@ -1,0 +1,7 @@
+extends: show
+summary: Retrieve a case history event by case ID and history ID
+uri: "cases/{case_id}/history/{history_id}"
+responseClass: CaseHistoryModel
+parameters:
+    case_id: { extends: id, required: true, location: uri }
+    history_id: { extends: id, required: true, location: uri }

--- a/tests/Desk/Test/Helper/Operation/ListOperationTestCase.php
+++ b/tests/Desk/Test/Helper/Operation/ListOperationTestCase.php
@@ -149,7 +149,7 @@ abstract class ListOperationTestCase extends OperationTestCase
     /**
      * Contains assertions to make about the results of the system test
      *
-     * @param array $models Resulting models from system test
+     * @param array $history Resulting models from system test
      */
-    abstract protected function assertSystem(array $models);
+    abstract protected function assertSystem(array $history);
 }

--- a/tests/Desk/Test/Helper/Operation/ListOperationTestCase.php
+++ b/tests/Desk/Test/Helper/Operation/ListOperationTestCase.php
@@ -149,7 +149,7 @@ abstract class ListOperationTestCase extends OperationTestCase
     /**
      * Contains assertions to make about the results of the system test
      *
-     * @param array $history Resulting models from system test
+     * @param array $models Resulting models from system test
      */
-    abstract protected function assertSystem(array $history);
+    abstract protected function assertSystem(array $models);
 }

--- a/tests/Desk/Test/Operation/Cases/History/ListCaseHistoryOperationTest.php
+++ b/tests/Desk/Test/Operation/Cases/History/ListCaseHistoryOperationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Desk\Test\Operation\Cases\History;
+
+use Guzzle\Service\Resource\Model;
+use Desk\Test\Helper\Operation\ListSubOperationTestCase;
+
+class ListCaseHistoryOperationTest extends ListSubOperationTestCase
+{
+
+    /**
+     * Contains assertions to make about the results of the system test
+     *
+     * @param Model[] $history Resulting models from system test
+     */
+    protected function assertSystem(array $history)
+    {
+        foreach ($history as $event) {
+            $this->assertEquals('CaseHistoryModel', $event->getStructure()->getName());
+        }
+
+        $this->assertCount(3, $history);
+
+        $event = $history[0];
+        $this->assertEquals('rule_applied', $event->get('type'));
+        $this->assertEquals('5540291e4d7d0a4d540006a5', $event->get('context'));
+        $this->assertInstanceOf('\DateTime', $event->get('created_at'));
+
+        $event = $history[1];
+        $this->assertEquals('case_updated', $event->get('type'));
+        $this->assertEquals('5540291e4d7d0a4d540006a5', $event->get('context'));
+        $this->assertInstanceOf('\DateTime', $event->get('created_at'));
+
+        $event = $history[2];
+        $this->assertEquals('rule_applied', $event->get('type'));
+        $this->assertEquals('5540291e4d7d0a4d540006a5', $event->get('context'));
+        $this->assertInstanceOf('\DateTime', $event->get('created_at'));
+    }
+
+    /**
+     * Gets the name of the property containing the main object's ID
+     *
+     * For example, if the operation is ListArticleTranslation, this
+     * function should return "article_id", as the "main object" is
+     * the article (which is having its translations listed).
+     *
+     * @return string
+     */
+    protected function getIdProperty()
+    {
+        return 'case_id';
+    }
+
+    /**
+     * The name of the operation to be tested
+     *
+     * This should be one of the keys under "operation" in the client's
+     * service description.
+     *
+     * @return string
+     */
+    protected function getOperationName()
+    {
+        return 'ListCaseHistory';
+    }
+}

--- a/tests/Desk/Test/Operation/Cases/History/ShowCaseHistoryOperation.php
+++ b/tests/Desk/Test/Operation/Cases/History/ShowCaseHistoryOperation.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Desk\Test\Operation\Cases\History;
+
+use Desk\Relationship\Resource\Model;
+use Desk\Test\Helper\Operation\ShowOperationTestCase;
+
+class ShowCaseHistoryOperation extends ShowOperationTestCase
+{
+    /**
+     * The name of the operation to be tested
+     *
+     * This should be one of the keys under "operation" in the client's
+     * service description.
+     *
+     * @return string
+     */
+    protected function getOperationName()
+    {
+        return 'ShowCaseHistory';
+    }
+
+    /**
+     * Contains assertions to make about the results of the system test
+     *
+     * @param array $model Resulting model from system test
+     */
+    protected function assertSystem(Model $model)
+    {
+        $this->assertEquals('CaseHistoryModel', $model->getStructure()->getName());
+
+        $this->assertEquals(2351, $model->get('id'));
+        $this->assertTrue($model->hasLink('self'));
+        $this->assertContains(2441978, $model->getPath('changes/*/to'));
+        $this->assertInstanceOf('\DateTime', $model->get('created_at'));
+    }
+}

--- a/tests/Desk/Test/Operation/Cases/ListCasesOperationTest.php
+++ b/tests/Desk/Test/Operation/Cases/ListCasesOperationTest.php
@@ -57,6 +57,11 @@ class ListCasesOperationTest extends ListOperationTestCase
         $this->assertSame('ShowGroup', $welcomeAssignedGroup->getName());
         $this->assertSame(1, $welcomeAssignedGroup->get('id'));
 
+        $welcomeHistory = $welcome->getLink('history');
+        $this->assertInstanceOf('Guzzle\\Service\\Command\\OperationCommand', $welcomeHistory);
+        $this->assertSame('ListCaseHistory', $welcomeHistory->getName());
+        $this->assertSame(1, $welcomeHistory->get('case_id'));
+
 
         $help = $cases[1];
         $this->assertSame('Help Please!', $help->get('subject'));
@@ -83,5 +88,10 @@ class ListCasesOperationTest extends ListOperationTestCase
         $this->assertInstanceOf('Guzzle\\Service\\Command\\OperationCommand', $helpAssignedGroup);
         $this->assertSame('ShowGroup', $helpAssignedGroup->getName());
         $this->assertSame(1, $helpAssignedGroup->get('id'));
+
+        $helpHistory = $help->getLink('history');
+        $this->assertInstanceOf('Guzzle\\Service\\Command\\OperationCommand', $helpHistory);
+        $this->assertSame('ListCaseHistory', $helpHistory->getName());
+        $this->assertSame(2, $helpHistory->get('case_id'));
     }
 }

--- a/tests/Desk/Test/Operation/Cases/SearchCasesOperationTest.php
+++ b/tests/Desk/Test/Operation/Cases/SearchCasesOperationTest.php
@@ -226,6 +226,11 @@ class SearchCasesOperationTest extends ListOperationTestCase
         $this->assertSame('ShowGroup', $welcomeAssignedGroup->getName());
         $this->assertSame(1, $welcomeAssignedGroup->get('id'));
 
+        $welcomeHistory = $welcome->getLink('history');
+        $this->assertInstanceOf('Guzzle\\Service\\Command\\OperationCommand', $welcomeHistory);
+        $this->assertSame('ListCaseHistory', $welcomeHistory->getName());
+        $this->assertSame(1, $welcomeHistory->get('case_id'));
+
 
         $help = $cases[1];
         $this->assertSame('Help Please!', $help->get('subject'));
@@ -257,5 +262,10 @@ class SearchCasesOperationTest extends ListOperationTestCase
         $this->assertInstanceOf('Guzzle\\Service\\Command\\OperationCommand', $helpAssignedGroup);
         $this->assertSame('ShowGroup', $helpAssignedGroup->getName());
         $this->assertSame(1, $helpAssignedGroup->get('id'));
+
+        $helpHistory = $help->getLink('history');
+        $this->assertInstanceOf('Guzzle\\Service\\Command\\OperationCommand', $helpHistory);
+        $this->assertSame('ListCaseHistory', $helpHistory->getName());
+        $this->assertSame(2, $helpHistory->get('case_id'));
     }
 }

--- a/tests/Desk/Test/Operation/Cases/ShowCaseOperationTest.php
+++ b/tests/Desk/Test/Operation/Cases/ShowCaseOperationTest.php
@@ -47,6 +47,12 @@ class ShowCaseOperationTest extends ShowOperationTestCase
         $this->assertSame(1335994728, $case->get('updated_at')->getTimestamp());
         $this->assertInstanceOf('DateTime', $case->get('received_at'));
         $this->assertSame(1335994728, $case->get('received_at')->getTimestamp());
+
+
+        $caseHistory = $case->getLink('history');
+        $this->assertInstanceOf('Guzzle\\Service\\Command\\OperationCommand', $caseHistory);
+        $this->assertSame('ListCaseHistory', $caseHistory->getName());
+        $this->assertSame(1, $caseHistory->get('case_id'));
     }
 
     /**

--- a/tests/mock/Desk/Test/Operation/Cases/History/ListCaseHistoryOperationTest/system.txt
+++ b/tests/mock/Desk/Test/Operation/Cases/History/ListCaseHistoryOperationTest/system.txt
@@ -1,0 +1,117 @@
+HTTP/1.1 200 OK
+Accept-Ranges: bytes
+Cache-Control: must-revalidate, private, max-age=0
+Content-Type: application/json; charset=utf-8
+Status: 200
+X-Rate-Limit-Limit: 60
+X-Rate-Limit-Remaining: 59
+X-Rate-Limit-Reset: 2
+Content-Length: 530
+Connection: keep-alive
+
+{
+    "total_entries": 3,
+    "page": 1,
+    "_links": {
+        "self": {
+            "href": "\/api\/v2\/cases\/1\/history?page=1&per_page=50",
+            "class": "page"
+        },
+        "first": {
+            "href": "\/api\/v2\/cases\/1\/history?page=1&per_page=50",
+            "class": "page"
+        },
+        "last": null,
+        "previous": null,
+        "next": null
+    },
+    "_embedded": {
+        "entries": [
+            {
+                "id": 9541523254,
+                "type": "rule_applied",
+                "context": "5540291e4d7d0a4d540006a5",
+                "created_at": "2015-04-29T00:43:10Z",
+                "changes": [
+                    {
+                        "field": "label_array",
+                        "from": null,
+                        "to": [
+                            5125124
+                        ]
+                    }
+                ],
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v2\/cases\/1\/history\/9541523254",
+                        "class": "history"
+                    },
+                    "invoker": {
+                        "href": "\/api\/v2\/users\/system",
+                        "class": "user"
+                    },
+                    "rule": {
+                        "href": "\/api\/v2\/rules\/2874172",
+                        "class": "rule"
+                    }
+                }
+            },
+            {
+                "id": 9541523293,
+                "type": "case_updated",
+                "context": "5540291e4d7d0a4d540006a5",
+                "created_at": "2015-04-29T00:43:10Z",
+                "changes": [
+                    {
+                        "field": "labels",
+                        "from": [
+
+                        ],
+                        "to": [
+                            "Test Label"
+                        ]
+                    }
+                ],
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v2\/cases\/1\/history\/9541523293",
+                        "class": "history"
+                    },
+                    "invoker": {
+                        "href": "\/api\/v2\/users\/system",
+                        "class": "user"
+                    }
+                }
+            },
+            {
+                "id": 9541523299,
+                "type": "rule_applied",
+                "context": "5540291e4d7d0a4d540006a5",
+                "created_at": "2015-04-29T00:43:10Z",
+                "changes": [
+                    {
+                        "field": "label_array",
+                        "from": null,
+                        "to": [
+                            2441978
+                        ]
+                    }
+                ],
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v2\/cases\/1\/history\/9541523299",
+                        "class": "history"
+                    },
+                    "invoker": {
+                        "href": "\/api\/v2\/users\/system",
+                        "class": "user"
+                    },
+                    "rule": {
+                        "href": "\/api\/v2\/rules\/2874206",
+                        "class": "rule"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/mock/Desk/Test/Operation/Cases/History/ShowCaseHistoryOperationTest/system.txt
+++ b/tests/mock/Desk/Test/Operation/Cases/History/ShowCaseHistoryOperationTest/system.txt
@@ -1,0 +1,32 @@
+HTTP/1.1 200 OK
+Accept-Ranges: bytes
+Cache-Control: must-revalidate, private, max-age=0
+Content-Type: application/json; charset=utf-8
+Status: 200
+X-Rate-Limit-Limit: 60
+X-Rate-Limit-Remaining: 59
+X-Rate-Limit-Reset: 2
+Content-Length: 530
+Connection: keep-alive
+
+{
+    "id": 2351,
+    "type": "rule_applied",
+    "context": "5540291e4d7d0a4d540006a5",
+    "created_at": "2015-04-29T00:43:10Z",
+    "changes": [
+        {
+            "field": "label_array",
+            "from": null,
+            "to": [
+                2441978
+            ]
+        }
+    ],
+    "_links": {
+        "self": {
+            "href": "\/api\/v2\/cases\/6165\/history\/2351",
+            "class": "history"
+        }
+    }
+}

--- a/tests/mock/Desk/Test/Operation/Cases/ListCasesOperationTest/system.txt
+++ b/tests/mock/Desk/Test/Operation/Cases/ListCasesOperationTest/system.txt
@@ -65,6 +65,10 @@ Connection: keep-alive
                         "href": "/api/v2/groups/1",
                         "class": "group"
                     },
+                    "history": {
+                        "href": "/api/v2/cases/1/history",
+                        "class": "case"
+                    },
                     "locked_by": null
                 }
             },
@@ -103,6 +107,10 @@ Connection: keep-alive
                     "assigned_group": {
                         "href": "/api/v2/groups/1",
                         "class": "group"
+                    },
+                    "history": {
+                        "href": "/api/v2/cases/2/history",
+                        "class": "case"
                     },
                     "locked_by": null
                 }

--- a/tests/mock/Desk/Test/Operation/Cases/SearchCasesOperationTest/system.txt
+++ b/tests/mock/Desk/Test/Operation/Cases/SearchCasesOperationTest/system.txt
@@ -70,6 +70,10 @@ Connection: keep-alive
                         "href": "/api/v2/groups/1",
                         "class": "group"
                     },
+                    "history": {
+                        "href": "/api/v2/cases/1/history",
+                        "class": "case"
+                    },
                     "locked_by": null
                 }
             },
@@ -113,6 +117,10 @@ Connection: keep-alive
                     "assigned_group": {
                         "href": "/api/v2/groups/1",
                         "class": "group"
+                    },
+                    "history": {
+                        "href": "/api/v2/cases/2/history",
+                        "class": "case"
                     },
                     "locked_by": null
                 }

--- a/tests/mock/Desk/Test/Operation/Cases/ShowCaseOperationTest/system.txt
+++ b/tests/mock/Desk/Test/Operation/Cases/ShowCaseOperationTest/system.txt
@@ -45,6 +45,10 @@ Connection: keep-alive
             "href": "/api/v2/groups/1",
             "class": "group"
         },
+        "history": {
+            "href": "/api/v2/cases/1/history",
+            "class": "case"
+        },
         "locked_by": null
     }
 }


### PR DESCRIPTION
Also adds support to get history from the links that are returned when listing, searching, or
showing cases.

http://dev.desk.com/API/cases/#history
