### PR TITLE
Fix case date params

### DIFF
--- a/lib/Desk/Filter/Date.php
+++ b/lib/Desk/Filter/Date.php
@@ -43,11 +43,20 @@ class Date
     /**
      * Converts a DateTime object to a timestamp
      *
-     * @param DateTime $date
+     * @param mixed $date
      * @return int
      */
-    public static function objectToTimestamp(DateTime $date)
+    public static function toTimestamp($date)
     {
-        return $date->getTimestamp();
+        if ($date instanceof DateTime) {
+            return $date->getTimestamp();
+        }
+
+        if (!is_numeric($date)) {
+            $date = new DateTime($date, new DateTimeZone('UTC'));
+            return $date->getTimestamp();
+        }
+
+        return $date;
     }
 }

--- a/lib/Desk/Filter/Date.php
+++ b/lib/Desk/Filter/Date.php
@@ -39,4 +39,15 @@ class Date
         $date->setTimezone(new DateTimeZone('UTC'));
         return $date->format("Y-m-d\\TH:i:s\\Z");
     }
+
+    /**
+     * Converts a DateTime object to a timestamp
+     *
+     * @param DateTime $date
+     * @return int
+     */
+    public static function objectToTimestamp(DateTime $date)
+    {
+        return $date->getTimestamp();
+    }
 }

--- a/lib/Desk/service-description/operations/Case.group/SearchCases.yaml
+++ b/lib/Desk/service-description/operations/Case.group/SearchCases.yaml
@@ -98,18 +98,22 @@ parameters:
         extends: date.input
         description: Search for cases created more recently than a particular date
         location: query
+        filters: Desk\Filter\Date::objectToTimestamp
     max_created_at:
         extends: date.input
         description: Search for cases created on or before a particular date
         location: query
+        filters: Desk\Filter\Date::objectToTimestamp
     since_updated_at:
         extends: date.input
         description: Search for cases updated more recently than a particular date
         location: query
+        filters: Desk\Filter\Date::objectToTimestamp
     max_updated_at:
         extends: date.input
         description: Search for cases updated on or before a particular date
         location: query
+        filters: Desk\Filter\Date::objectToTimestamp
     since_id:
         extends: id
         description: Search for cases with an ID greater than a particular ID

--- a/lib/Desk/service-description/operations/Case.group/SearchCases.yaml
+++ b/lib/Desk/service-description/operations/Case.group/SearchCases.yaml
@@ -95,25 +95,25 @@ parameters:
         description: Updated date range to filter by
         location: query
     since_created_at:
-        extends: date.input
+        extends: parameter
         description: Search for cases created more recently than a particular date
         location: query
-        filters: Desk\Filter\Date::objectToTimestamp
+        filters: Desk\Filter\Date::toTimestamp
     max_created_at:
-        extends: date.input
+        extends: parameter
         description: Search for cases created on or before a particular date
         location: query
-        filters: Desk\Filter\Date::objectToTimestamp
+        filters: Desk\Filter\Date::toTimestamp
     since_updated_at:
-        extends: date.input
+        extends: parameter
         description: Search for cases updated more recently than a particular date
         location: query
-        filters: Desk\Filter\Date::objectToTimestamp
+        filters: Desk\Filter\Date::toTimestamp
     max_updated_at:
-        extends: date.input
+        extends: parameter
         description: Search for cases updated on or before a particular date
         location: query
-        filters: Desk\Filter\Date::objectToTimestamp
+        filters: Desk\Filter\Date::toTimestamp
     since_id:
         extends: id
         description: Search for cases with an ID greater than a particular ID

--- a/tests/Desk/Test/Operation/Cases/SearchCasesOperationTest.php
+++ b/tests/Desk/Test/Operation/Cases/SearchCasesOperationTest.php
@@ -111,19 +111,19 @@ class SearchCasesOperationTest extends ListOperationTestCase
             ),
             array(
                 array('since_created_at' => $date),
-                array('query' => '#^since_created_at=2013-06-14T13%3A00%3A00Z$#'),
+                array('query' => '#^since_created_at=1371214800$#'),
             ),
             array(
                 array('max_created_at' => $date),
-                array('query' => '#^max_created_at=2013-06-14T13%3A00%3A00Z$#'),
+                array('query' => '#^max_created_at=1371214800$#'),
             ),
             array(
                 array('since_updated_at' => $date),
-                array('query' => '#^since_updated_at=2013-06-14T13%3A00%3A00Z$#'),
+                array('query' => '#^since_updated_at=1371214800$#'),
             ),
             array(
                 array('max_updated_at' => $date),
-                array('query' => '#^max_updated_at=2013-06-14T13%3A00%3A00Z$#'),
+                array('query' => '#^max_updated_at=1371214800$#'),
             ),
             array(
                 array('since_id' => 7),
@@ -162,10 +162,6 @@ class SearchCasesOperationTest extends ListOperationTestCase
             array(array('attachments' => false)),
             array(array('created' => 'tomorrow')),
             array(array('updated' => 'invalid')),
-            array(array('since_created_at' => '123')),
-            array(array('max_created_at' => 234)),
-            array(array('since_updated_at' => 34.5)),
-            array(array('max_updated_at' => true)),
             array(array('max_id' => 56.3)),
         );
     }

--- a/tests/Desk/Test/Unit/Filter/DateTest.php
+++ b/tests/Desk/Test/Unit/Filter/DateTest.php
@@ -70,4 +70,24 @@ class DateTest extends UnitTestCase
             ),
         );
     }
+
+    /**
+     * @dataProvider dataToTimestamp
+     * @param $date
+     * @param $expected
+     */
+    public function testToTimestamp($date, $expected)
+    {
+        $actual = Date::toTimestamp($date);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function dataToTimestamp()
+    {
+        return array(
+            array(new DateTime('2013-05-24T16:55:02Z'), 1369414502),
+            array(1369414502, 1369414502),
+            array('2013-05-24T16:55:02Z', 1369414502)
+        );
+    }
 }


### PR DESCRIPTION
When using the `since_created_at`, `max_created_at`, `max_updated_at`, and `since_updated_at` properties with the Case API, it expects the unix timestamp. Previously the date string would be sent causing the value to be ignored. 
